### PR TITLE
Better Django runrpcserver command

### DIFF
--- a/manifold/handler.py
+++ b/manifold/handler.py
@@ -52,7 +52,9 @@ class ServiceHandler:
 
     def print_current_mappings(self):
         for mapped_name in self.__mapped_names:
-            print(f'* {mapped_name} -- {getattr(self, mapped_name).__name__}')
+            func = getattr(self, mapped_name)
+            name = f'{func.__module__}.{func.__name__}'
+            print(f'* {mapped_name} -- {name}')
 
     def __getattribute__(self, name):
         """Overridden to set the New Relic transaction name if handler.

--- a/manifold/management/commands/runrpcserver.py
+++ b/manifold/management/commands/runrpcserver.py
@@ -13,11 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import os
+import sys
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.utils import autoreload
 
 from manifold import rpc
+
+
+def get_manifold_version():
+    import manifold
+    return manifold.__version__
 
 
 class Command(BaseCommand):
@@ -27,16 +34,25 @@ class Command(BaseCommand):
         parser.add_argument('host', type=str, nargs='?', default='127.0.0.1')
         parser.add_argument('port', type=int, nargs='?', default=9090)
 
-    def handle(self, *args, **options):
-        if os.environ.get('RUN_MAIN') == 'true':
-            return
-
-        host = options.get('host', '127.0.0.1')
-        port = options.get('port', 9090)
+    def run_server(self, host, port):
+        autoreload.raise_last_exception()
+        quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
 
         self.stdout.write(
-            'Starting Thrift RPC server running @ %s:%s' % (host, port)
+            f"Django Manifold version {get_manifold_version()}\n"
+            f"Django version {self.get_version()}, "
+            f"using settings {settings.SETTINGS_MODULE}\n"
+            f"Starting development RPC server at {host}:{port}\n"
+            f"Quit the server with {quit_command}.\n"
         )
 
         server = rpc.make_server()
         server.serve()
+
+    def handle(self, *args, **options):
+        host = options.get('host', '127.0.0.1')
+        port = options.get('port', 9090)
+
+        # self.run_server(host, port)
+
+        autoreload.main(self.run_server, args=(host, port), kwargs=None)

--- a/manifold/rpc.py
+++ b/manifold/rpc.py
@@ -48,7 +48,7 @@ def _print_rpc_config(handler):
     global __configured
     if __configured:
         return
-    print('\n** Manifold RPC Function Mappings **')
+    print('\n** Manifold RPC --> Function Mappings **')
     handler.print_current_mappings()
     print()
     __configured = True
@@ -130,6 +130,3 @@ def make_client(key='default'):
     host = thrift_settings.get('host', '127.0.0.1')
     port = thrift_settings.get('port', 9090)
     return thrift_client(load_service(key), host=host, port=port)
-
-
-app = get_rpc_application()


### PR DESCRIPTION
## Description
<!--- Describe the purpose of this pull request and an overview of the changes. -->
Implemented a better `runrpcserver` command that mimics how the standard `runserver` Django command works, including nice development print outs, autoreloading, and more. A screenshot of a run is below.

<img width="520" alt="screen shot 2018-03-28 at 11 48 32 am" src="https://user-images.githubusercontent.com/10478871/38040678-04f314ae-327e-11e8-91f3-d2e0c3dfc8ae.png">

**IMPORTANT - Breaking Change**

The `app` from `manifold.rpc` was removed, so now you will *need* to call `get_rpc_application` instead of just using the previous default `gunicorn_thrift manifold.rpc:app`.

**Change Log**

<!--- Walk through the files you have updated and document the major changes and reasons. --->
<!--- Each item should be numbered and explain technical details of the implementation.  --->
<!--- Pretend you are justifying each change to the engineer next to you. -->

1. `get_rpc_application()`'s printout now includes the entire module path to the mapped function, making it clearer and more readable on what is mapped to what.
2. Auto-reloading added to `runrpcserver` command, because no one likes to have to start and stop after minor changes.

## Test Plan
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes local testing.

### Race Conditions / Edge Cases
<!-- Include things that can be monitored at the application level -->
<!-- If you can think of any potential edge cases include them here -->
See breaking change above