### PR TITLE
Releasing Latest to v1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All changes will be reflected here in reverse chronological order going down the
 
 ## Latest (Unreleased)
 
+* No current changes.
+
+## Version 1.2
+
 * Added HTTP server wrapper around RPC ServiceHandler, allowing the service to be served using HTTP and JSON POSTs requests.
 * `docs` directory added with all of the documentation.
 * `runrpcserver` command updated to give more information and to run with autoreloader.
 * Error messages for invalid validator fields give more concise and helpful information.
+* Caches `load_module` modules.
 
 ## Version 1.1
 

--- a/manifold/__init__.py
+++ b/manifold/__init__.py
@@ -1,4 +1,4 @@
 __title__ = 'django-manifold'
-__version__ = '1.1'
+__version__ = '1.2'
 __author__ = 'ACV Auctions'
 __email__ = 'dstarner@acvauctions.com'


### PR DESCRIPTION
From the `CHANGELOG.md`

## Description
* Added HTTP server wrapper around RPC ServiceHandler, allowing the service to be served using HTTP and JSON POSTs requests.
* `docs` directory added with all of the documentation.
* `runrpcserver` command updated to give more information and to run with autoreloader.
* Error messages for invalid validator fields give more concise and helpful information.
* Caches `load_module` modules.
